### PR TITLE
Add pthread as an extra-libraries.

### DIFF
--- a/thread-local-storage.cabal
+++ b/thread-local-storage.cabal
@@ -49,8 +49,9 @@ library
   -- hs-source-dirs:      
   default-language:    Haskell2010
   ghc-options: -Wall -O2
-  c-sources: cbits/helpers.c  
-     
+  c-sources: cbits/helpers.c
+  extra-libraries: pthread
+
 benchmark bench-haskell-tls
   main-is: Main.hs
   hs-source-dirs: ./bench/


### PR DESCRIPTION
Without this, programs that have this library as a dependency need to
link pthread explicitly in their own cabal files. But that's arguably
a leak of internal implementation details.

What's weird is that downstream programs need to link pthread
explicitly only on some systems, not all. But this ought to fix it.
