### PR TITLE
Add lpthread flag to support systems that have implicitly pthread

### DIFF
--- a/thread-local-storage.cabal
+++ b/thread-local-storage.cabal
@@ -33,6 +33,11 @@ source-repository head
   type:     git
   location: https://github.com/rrnewton/thread-local-storage
 
+flag lpthread
+  description: Needs -lpthread. E.g. android doesn't need it.
+  default:     True
+  manual:      True
+
 library
   exposed-modules:     Data.TLS.GHC,
                        Data.TLS.PThread
@@ -45,7 +50,8 @@ library
   default-language:    Haskell2010
   ghc-options: -Wall -O2
   c-sources: cbits/helpers.c
-  extra-libraries: pthread
+  if flag(lpthread)
+    extra-libraries: pthread
 
 benchmark bench-haskell-tls
   main-is: Main.hs


### PR DESCRIPTION
Android's bionic comes with pthread built in, and hence -lpthread is invalid. This adds a flag, such that
`cabal -f-lpthread`, allows this package to be cross compiled to android.