### PR TITLE
Implement PThread.mkTLSWithDestructor.

### DIFF
--- a/Data/TLS/PThread.hs
+++ b/Data/TLS/PThread.hs
@@ -15,6 +15,7 @@
 module Data.TLS.PThread
     ( TLS
     , mkTLS
+    , mkTLSWithDestructor
     , getTLS
     , allTLS
     , forEachTLS_

--- a/cbits/helpers.c
+++ b/cbits/helpers.c
@@ -7,9 +7,9 @@ long get_pthread_key_size() {
   return sizeof(pthread_key_t);
 }
 
-pthread_key_t easy_make_pthread_key() {
+pthread_key_t easy_make_pthread_key(void (*destructor)(void*)) {
   pthread_key_t key;
-  int rc = pthread_key_create(&key, NULL);
+  int rc = pthread_key_create(&key, destructor);
   if (rc) {
     fprintf(stderr, "pthread_key_create returned error code: %d\n", rc);
     abort();


### PR DESCRIPTION
This is a variant of mkTLS which allows to specify a destructor function that each thread can call on exit to cleanup their copies of the TLS variables.

The plan is to use this feature in the package `jni` to detach threads from the JVM before they exit.

This patch also includes a fix to a potential problem which could produces multiple copies of a variable for the same thread. See the Note [Ptr indirection] in the patch.